### PR TITLE
Use pyqt5 instead of PySide6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "sum_dirac_dfcoef",
-  "pyside6",
+  "pyqt5",
   "qtpy",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pyside6
+pyqt5
 qtpy
 sum-dirac-dfcoef


### PR DESCRIPTION
- If user uses Linux, libxcb-cursor.so.0 is not installed by default, but PySide6 requires this library, so use pyqt5