### PR TITLE
Skip first row when creating row dictionary in TableWidget

### DIFF
--- a/src/dcaspt2_input_generator/components/table_widget.py
+++ b/src/dcaspt2_input_generator/components/table_widget.py
@@ -139,6 +139,8 @@ class TableWidget(QTableWidget):
             table_data.mo_data = []
             try:
                 for idx, row in enumerate(rows):
+                    if idx == 0:
+                        continue
                     row_dict = create_row_dict(row)
                     table_data.mo_data.append(row_dict)
                     table_data.column_max_len = max(table_data.column_max_len, len(row))


### PR DESCRIPTION
Because first row of sum_dirac_dfcoef output is header information
from version >= 2
c.f. https://github.com/minoria-hiroshima/sum_dirac_dfcoef/releases/tag/v2.0.0

I need to implement read and parse this information properly,
but skip the first line as a temporary fix.